### PR TITLE
fix linting issues with golangci-lint 1.60.2

### DIFF
--- a/cmd/compatibility/convert.go
+++ b/cmd/compatibility/convert.go
@@ -63,7 +63,7 @@ ARGS:
 			command = append([]string{arg}, command...)
 			continue
 		}
-		if len(arg) > 0 && arg[0] != '-' {
+		if arg != "" && arg[0] != '-' {
 			command = append(command, args[i:]...)
 			break
 		}

--- a/cmd/compose/config.go
+++ b/cmd/compose/config.go
@@ -284,7 +284,7 @@ func runServices(ctx context.Context, dockerCli command.Cli, opts configOptions)
 		return err
 	}
 	err = project.ForEachService(project.ServiceNames(), func(serviceName string, _ *types.ServiceConfig) error {
-		fmt.Fprintln(dockerCli.Out(), serviceName)
+		_, _ = fmt.Fprintln(dockerCli.Out(), serviceName)
 		return nil
 	})
 	return err
@@ -296,7 +296,7 @@ func runVolumes(ctx context.Context, dockerCli command.Cli, opts configOptions) 
 		return err
 	}
 	for n := range project.Volumes {
-		fmt.Fprintln(dockerCli.Out(), n)
+		_, _ = fmt.Fprintln(dockerCli.Out(), n)
 	}
 	return nil
 }
@@ -335,7 +335,7 @@ func runHash(ctx context.Context, dockerCli command.Cli, opts configOptions) err
 		if err != nil {
 			return err
 		}
-		fmt.Fprintf(dockerCli.Out(), "%s %s\n", name, hash)
+		_, _ = fmt.Fprintf(dockerCli.Out(), "%s %s\n", name, hash)
 	}
 	return nil
 }
@@ -357,7 +357,7 @@ func runProfiles(ctx context.Context, dockerCli command.Cli, opts configOptions,
 	}
 	sort.Strings(profiles)
 	for _, p := range profiles {
-		fmt.Fprintln(dockerCli.Out(), p)
+		_, _ = fmt.Fprintln(dockerCli.Out(), p)
 	}
 	return nil
 }
@@ -369,7 +369,7 @@ func runConfigImages(ctx context.Context, dockerCli command.Cli, opts configOpti
 	}
 
 	for _, s := range project.Services {
-		fmt.Fprintln(dockerCli.Out(), api.GetImageNameOrDefault(s, project.Name))
+		_, _ = fmt.Fprintln(dockerCli.Out(), api.GetImageNameOrDefault(s, project.Name))
 	}
 	return nil
 }

--- a/cmd/compose/events.go
+++ b/cmd/compose/events.go
@@ -72,9 +72,9 @@ func runEvents(ctx context.Context, dockerCli command.Cli, backend api.Service, 
 				if err != nil {
 					return err
 				}
-				fmt.Fprintln(dockerCli.Out(), string(marshal))
+				_, _ = fmt.Fprintln(dockerCli.Out(), string(marshal))
 			} else {
-				fmt.Fprintln(dockerCli.Out(), event)
+				_, _ = fmt.Fprintln(dockerCli.Out(), event)
 			}
 			return nil
 		},

--- a/cmd/compose/images.go
+++ b/cmd/compose/images.go
@@ -81,7 +81,7 @@ func runImages(ctx context.Context, dockerCli command.Cli, backend api.Service, 
 			}
 		}
 		for _, img := range ids {
-			fmt.Fprintln(dockerCli.Out(), img)
+			_, _ = fmt.Fprintln(dockerCli.Out(), img)
 		}
 		return nil
 	}

--- a/cmd/compose/list.go
+++ b/cmd/compose/list.go
@@ -86,7 +86,7 @@ func runList(ctx context.Context, dockerCli command.Cli, backend api.Service, ls
 
 	if lsOpts.Quiet {
 		for _, s := range stackList {
-			fmt.Fprintln(dockerCli.Out(), s.Name)
+			_, _ = fmt.Fprintln(dockerCli.Out(), s.Name)
 		}
 		return nil
 	}

--- a/cmd/compose/port.go
+++ b/cmd/compose/port.go
@@ -75,6 +75,6 @@ func runPort(ctx context.Context, dockerCli command.Cli, backend api.Service, op
 		return err
 	}
 
-	fmt.Fprintf(dockerCli.Out(), "%s:%d\n", ip, port)
+	_, _ = fmt.Fprintf(dockerCli.Out(), "%s:%d\n", ip, port)
 	return nil
 }

--- a/cmd/compose/ps.go
+++ b/cmd/compose/ps.go
@@ -130,7 +130,7 @@ func runPs(ctx context.Context, dockerCli command.Cli, backend api.Service, serv
 
 	if opts.Quiet {
 		for _, c := range containers {
-			fmt.Fprintln(dockerCli.Out(), c.ID)
+			_, _ = fmt.Fprintln(dockerCli.Out(), c.ID)
 		}
 		return nil
 	}
@@ -143,7 +143,7 @@ func runPs(ctx context.Context, dockerCli command.Cli, backend api.Service, serv
 				services = append(services, s)
 			}
 		}
-		fmt.Fprintln(dockerCli.Out(), strings.Join(services, "\n"))
+		_, _ = fmt.Fprintln(dockerCli.Out(), strings.Join(services, "\n"))
 		return nil
 	}
 

--- a/cmd/compose/top.go
+++ b/cmd/compose/top.go
@@ -64,7 +64,7 @@ func runTop(ctx context.Context, dockerCli command.Cli, backend api.Service, opt
 	})
 
 	for _, container := range containers {
-		fmt.Fprintf(dockerCli.Out(), "%s\n", container.Name)
+		_, _ = fmt.Fprintf(dockerCli.Out(), "%s\n", container.Name)
 		err := psPrinter(dockerCli.Out(), func(w io.Writer) {
 			for _, proc := range container.Processes {
 				info := []interface{}{}
@@ -74,7 +74,7 @@ func runTop(ctx context.Context, dockerCli command.Cli, backend api.Service, opt
 				_, _ = fmt.Fprintf(w, strings.Repeat("%s\t", len(info))+"\n", info...)
 
 			}
-			fmt.Fprintln(w)
+			_, _ = fmt.Fprintln(w)
 		},
 			container.Titles...)
 		if err != nil {

--- a/cmd/compose/version.go
+++ b/cmd/compose/version.go
@@ -59,12 +59,12 @@ func versionCommand(dockerCli command.Cli) *cobra.Command {
 
 func runVersion(opts versionOptions, dockerCli command.Cli) {
 	if opts.short {
-		fmt.Fprintln(dockerCli.Out(), strings.TrimPrefix(internal.Version, "v"))
+		_, _ = fmt.Fprintln(dockerCli.Out(), strings.TrimPrefix(internal.Version, "v"))
 		return
 	}
 	if opts.format == formatter.JSON {
-		fmt.Fprintf(dockerCli.Out(), "{\"version\":%q}\n", internal.Version)
+		_, _ = fmt.Fprintf(dockerCli.Out(), "{\"version\":%q}\n", internal.Version)
 		return
 	}
-	fmt.Fprintln(dockerCli.Out(), "Docker Compose version", internal.Version)
+	_, _ = fmt.Fprintln(dockerCli.Out(), "Docker Compose version", internal.Version)
 }

--- a/cmd/formatter/logs.go
+++ b/cmd/formatter/logs.go
@@ -115,9 +115,9 @@ func (l *logConsumer) write(w io.Writer, container, message string) {
 	timestamp := time.Now().Format(jsonmessage.RFC3339NanoFixed)
 	for _, line := range strings.Split(message, "\n") {
 		if l.timestamp {
-			fmt.Fprintf(w, "%s%s%s\n", p.prefix, timestamp, line)
+			_, _ = fmt.Fprintf(w, "%s%s%s\n", p.prefix, timestamp, line)
 		} else {
-			fmt.Fprintf(w, "%s%s\n", p.prefix, line)
+			_, _ = fmt.Fprintf(w, "%s%s\n", p.prefix, line)
 		}
 	}
 

--- a/pkg/compose/attach.go
+++ b/pkg/compose/attach.go
@@ -50,7 +50,7 @@ func (s *composeService) attach(ctx context.Context, project *types.Project, lis
 		names = append(names, getContainerNameWithoutProject(c))
 	}
 
-	fmt.Fprintf(s.stdout(), "Attaching to %s\n", strings.Join(names, ", "))
+	_, _ = fmt.Fprintf(s.stdout(), "Attaching to %s\n", strings.Join(names, ", "))
 
 	for _, container := range containers {
 		err := s.attachContainer(ctx, container, listener)

--- a/pkg/compose/build.go
+++ b/pkg/compose/build.go
@@ -172,7 +172,7 @@ func (s *composeService) build(ctx context.Context, project *types.Project, opti
 		}
 
 		if options.Memory != 0 {
-			fmt.Fprintln(s.stderr(), "WARNING: --memory is not supported by BuildKit and will be ignored")
+			_, _ = fmt.Fprintln(s.stderr(), "WARNING: --memory is not supported by BuildKit and will be ignored")
 		}
 
 		buildOptions, err := s.toBuildOptions(project, service, options)
@@ -542,8 +542,8 @@ func getImageBuildLabels(project *types.Project, service types.ServiceConfig) ty
 
 func toBuildContexts(additionalContexts types.Mapping) map[string]build.NamedContext {
 	namedContexts := map[string]build.NamedContext{}
-	for name, context := range additionalContexts {
-		namedContexts[name] = build.NamedContext{Path: context}
+	for name, contextPath := range additionalContexts {
+		namedContexts[name] = build.NamedContext{Path: contextPath}
 	}
 	return namedContexts
 }

--- a/pkg/compose/build_classic.go
+++ b/pkg/compose/build_classic.go
@@ -205,7 +205,7 @@ func (s *composeService) doBuildClassic(ctx context.Context, project *types.Proj
 	// daemon isn't running Windows.
 	if response.OSType != "windows" && runtime.GOOS == "windows" {
 		// if response.OSType != "windows" && runtime.GOOS == "windows" && !options.quiet {
-		fmt.Fprintln(s.stdout(), "SECURITY WARNING: You are building a Docker "+
+		_, _ = fmt.Fprintln(s.stdout(), "SECURITY WARNING: You are building a Docker "+
 			"image from Windows against a non-Windows Docker host. All files and "+
 			"directories added to build context will have '-rwxr-xr-x' permissions. "+
 			"It is recommended to double check and reset permissions for sensitive "+

--- a/pkg/compose/compose.go
+++ b/pkg/compose/compose.go
@@ -191,7 +191,7 @@ func (s *composeService) projectFromName(containers Containers, projectName stri
 	}
 	for name, service := range set {
 		dependencies := service.Labels[api.DependenciesLabel]
-		if len(dependencies) > 0 {
+		if dependencies != "" {
 			service.DependsOn = types.DependsOnConfig{}
 			for _, dc := range strings.Split(dependencies, ",") {
 				dcArr := strings.Split(dc, ":")

--- a/pkg/compose/convergence.go
+++ b/pkg/compose/convergence.go
@@ -458,7 +458,7 @@ func shouldWaitForDependency(serviceName string, dependencyConfig types.ServiceD
 }
 
 func nextContainerNumber(containers []moby.Container) int {
-	max := 0
+	maxNumber := 0
 	for _, c := range containers {
 		s, ok := c.Labels[api.ContainerNumberLabel]
 		if !ok {
@@ -469,11 +469,11 @@ func nextContainerNumber(containers []moby.Container) int {
 			logrus.Warnf("container %s has invalid %s label: %s", c.ID, api.ContainerNumberLabel, s)
 			continue
 		}
-		if n > max {
-			max = n
+		if n > maxNumber {
+			maxNumber = n
 		}
 	}
-	return max + 1
+	return maxNumber + 1
 
 }
 

--- a/pkg/compose/kill.go
+++ b/pkg/compose/kill.go
@@ -57,7 +57,7 @@ func (s *composeService) kill(ctx context.Context, projectName string, options a
 		containers = containers.filter(isService(project.ServiceNames()...))
 	}
 	if len(containers) == 0 {
-		fmt.Fprintf(s.stdinfo(), "no container to kill")
+		_, _ = fmt.Fprintf(s.stdinfo(), "no container to kill")
 		return nil
 	}
 

--- a/pkg/compose/remove.go
+++ b/pkg/compose/remove.go
@@ -46,7 +46,7 @@ func (s *composeService) Remove(ctx context.Context, projectName string, options
 	containers, err := s.getContainers(ctx, projectName, oneOffExclude, true, options.Services...)
 	if err != nil {
 		if api.IsNotFoundError(err) {
-			fmt.Fprintln(s.stderr(), "No stopped containers")
+			_, _ = fmt.Fprintln(s.stderr(), "No stopped containers")
 			return nil
 		}
 		return err
@@ -78,12 +78,12 @@ func (s *composeService) Remove(ctx context.Context, projectName string, options
 	})
 
 	if len(names) == 0 {
-		fmt.Fprintln(s.stdinfo(), "No stopped containers")
+		_, _ = fmt.Fprintln(s.stdinfo(), "No stopped containers")
 		return nil
 	}
 	msg := fmt.Sprintf("Going to remove %s", strings.Join(names, ", "))
 	if options.Force {
-		fmt.Fprintln(s.stdout(), msg)
+		_, _ = fmt.Fprintln(s.stdout(), msg)
 	} else {
 		confirm, err := prompt.NewPrompt(s.stdin(), s.stdout()).Confirm(msg, false)
 		if err != nil {

--- a/pkg/compose/run.go
+++ b/pkg/compose/run.go
@@ -124,7 +124,7 @@ func applyRunOptions(project *types.Project, service *types.ServiceConfig, opts 
 	if len(opts.Command) > 0 {
 		service.Command = opts.Command
 	}
-	if len(opts.User) > 0 {
+	if opts.User != "" {
 		service.User = opts.User
 	}
 
@@ -136,7 +136,7 @@ func applyRunOptions(project *types.Project, service *types.ServiceConfig, opts 
 		service.CapDrop = append(service.CapDrop, opts.CapDrop...)
 		service.CapAdd = utils.Remove(service.CapAdd, opts.CapDrop...)
 	}
-	if len(opts.WorkingDir) > 0 {
+	if opts.WorkingDir != "" {
 		service.WorkingDir = opts.WorkingDir
 	}
 	if opts.Entrypoint != nil {

--- a/pkg/compose/up.go
+++ b/pkg/compose/up.go
@@ -55,7 +55,7 @@ func (s *composeService) Up(ctx context.Context, project *types.Project, options
 		return err
 	}
 	if s.dryRun {
-		fmt.Fprintln(s.stdout(), "end of 'compose up' output, interactive run is not supported in dry-run mode")
+		_, _ = fmt.Fprintln(s.stdout(), "end of 'compose up' output, interactive run is not supported in dry-run mode")
 		return err
 	}
 
@@ -77,7 +77,7 @@ func (s *composeService) Up(ctx context.Context, project *types.Project, options
 		first := true
 		gracefulTeardown := func() {
 			printer.Cancel()
-			fmt.Fprintln(s.stdinfo(), "Gracefully stopping... (press Ctrl+C again to force)")
+			_, _ = fmt.Fprintln(s.stdinfo(), "Gracefully stopping... (press Ctrl+C again to force)")
 			eg.Go(func() error {
 				err := s.Stop(context.WithoutCancel(ctx), project.Name, api.StopOptions{
 					Services: options.Create.Services,
@@ -144,7 +144,7 @@ func (s *composeService) Up(ctx context.Context, project *types.Project, options
 	var exitCode int
 	eg.Go(func() error {
 		code, err := printer.Run(options.Start.OnExit, options.Start.ExitCodeFrom, func() error {
-			fmt.Fprintln(s.stdinfo(), "Aborting on container exit...")
+			_, _ = fmt.Fprintln(s.stdinfo(), "Aborting on container exit...")
 			return progress.Run(ctx, func(ctx context.Context) error {
 				return s.Stop(ctx, project.Name, api.StopOptions{
 					Services: options.Create.Services,

--- a/pkg/compose/viz.go
+++ b/pkg/compose/viz.go
@@ -88,7 +88,7 @@ func addNodes(graphBuilder *strings.Builder, graph vizGraph, projectName string,
 			graphBuilder.WriteString("<br/><br/><b>Ports:</b>")
 			for _, portConfig := range serviceNode.Ports {
 				graphBuilder.WriteString("<br/>")
-				if len(portConfig.HostIP) > 0 {
+				if portConfig.HostIP != "" {
 					graphBuilder.WriteString(portConfig.HostIP)
 					graphBuilder.WriteByte(':')
 				}

--- a/pkg/compose/wait.go
+++ b/pkg/compose/wait.go
@@ -43,7 +43,7 @@ func (s *composeService) Wait(ctx context.Context, projectName string, options a
 
 			select {
 			case result := <-resultC:
-				fmt.Fprintf(s.dockerCli.Out(), "container %q exited with status code %d\n", c.ID, result.StatusCode)
+				_, _ = fmt.Fprintf(s.dockerCli.Out(), "container %q exited with status code %d\n", c.ID, result.StatusCode)
 				statusCode = result.StatusCode
 			case err = <-errC:
 			}

--- a/pkg/e2e/watch_test.go
+++ b/pkg/e2e/watch_test.go
@@ -205,7 +205,7 @@ func doTest(t *testing.T, svcName string) {
 			if strings.Contains(res.Stdout(), contents) {
 				return poll.Success()
 			}
-			return poll.Continue(res.Combined())
+			return poll.Continue("%v", res.Combined())
 		}
 	}
 
@@ -287,7 +287,7 @@ func doTest(t *testing.T, svcName string) {
 			if strings.Contains(r.Combined(), state) {
 				return poll.Success()
 			}
-			return poll.Continue(r.Combined())
+			return poll.Continue("%v", r.Combined())
 		}
 	}
 	poll.WaitOn(t, checkRestart(fmt.Sprintf("%s-1  Restarting", svcName)))

--- a/pkg/progress/json.go
+++ b/pkg/progress/json.go
@@ -64,7 +64,7 @@ func (p *jsonWriter) Event(e Event) {
 	}
 	marshal, err := json.Marshal(message)
 	if err == nil {
-		fmt.Fprintln(p.out, string(marshal))
+		_, _ = fmt.Fprintln(p.out, string(marshal))
 	}
 }
 
@@ -84,7 +84,7 @@ func (p *jsonWriter) TailMsgf(msg string, args ...interface{}) {
 	}
 	marshal, err := json.Marshal(message)
 	if err == nil {
-		fmt.Fprintln(p.out, string(marshal))
+		_, _ = fmt.Fprintln(p.out, string(marshal))
 	}
 }
 

--- a/pkg/progress/plain.go
+++ b/pkg/progress/plain.go
@@ -44,7 +44,7 @@ func (p *plainWriter) Event(e Event) {
 	if p.dryRun {
 		prefix = api.DRYRUN_PREFIX
 	}
-	fmt.Fprintln(p.out, prefix, e.ID, e.Text, e.StatusText)
+	_, _ = fmt.Fprintln(p.out, prefix, e.ID, e.Text, e.StatusText)
 }
 
 func (p *plainWriter) Events(events []Event) {
@@ -58,7 +58,7 @@ func (p *plainWriter) TailMsgf(msg string, args ...interface{}) {
 	if p.dryRun {
 		msg = api.DRYRUN_PREFIX + msg
 	}
-	fmt.Fprintln(p.out, msg)
+	_, _ = fmt.Fprintln(p.out, msg)
 }
 
 func (p *plainWriter) Stop() {

--- a/pkg/progress/tty.go
+++ b/pkg/progress/tty.go
@@ -140,7 +140,7 @@ func (w *ttyWriter) printTailEvents() {
 	w.mtx.Lock()
 	defer w.mtx.Unlock()
 	for _, msg := range w.tailEvents {
-		fmt.Fprintln(w.out, msg)
+		_, _ = fmt.Fprintln(w.out, msg)
 	}
 }
 
@@ -159,17 +159,19 @@ func (w *ttyWriter) print() { //nolint:gocyclo
 		b = b.Down(1)
 	}
 	w.repeated = true
-	fmt.Fprint(w.out, b.Column(0).ANSI)
+	_, _ = fmt.Fprint(w.out, b.Column(0).ANSI)
 
 	// Hide the cursor while we are printing
-	fmt.Fprint(w.out, aec.Hide)
-	defer fmt.Fprint(w.out, aec.Show)
+	_, _ = fmt.Fprint(w.out, aec.Hide)
+	defer func() {
+		_, _ = fmt.Fprint(w.out, aec.Show)
+	}()
 
 	firstLine := fmt.Sprintf("[+] %s %d/%d", w.progressTitle, numDone(w.events), w.numLines)
 	if w.numLines != 0 && numDone(w.events) == w.numLines {
 		firstLine = DoneColor(firstLine)
 	}
-	fmt.Fprintln(w.out, firstLine)
+	_, _ = fmt.Fprintln(w.out, firstLine)
 
 	var statusPadding int
 	for _, v := range w.eventIDs {
@@ -193,7 +195,7 @@ func (w *ttyWriter) print() { //nolint:gocyclo
 			continue
 		}
 		line := w.lineText(event, "", terminalWidth, statusPadding, w.dryRun)
-		fmt.Fprint(w.out, line)
+		_, _ = fmt.Fprint(w.out, line)
 		numLines++
 		for _, v := range w.eventIDs {
 			ev := w.events[v]
@@ -202,14 +204,14 @@ func (w *ttyWriter) print() { //nolint:gocyclo
 					continue
 				}
 				line := w.lineText(ev, "  ", terminalWidth, statusPadding, w.dryRun)
-				fmt.Fprint(w.out, line)
+				_, _ = fmt.Fprint(w.out, line)
 				numLines++
 			}
 		}
 	}
 	for i := numLines; i < w.numLines; i++ {
 		if numLines < goterm.Height()-2 {
-			fmt.Fprintln(w.out, strings.Repeat(" ", terminalWidth))
+			_, _ = fmt.Fprintln(w.out, strings.Repeat(" ", terminalWidth))
 			numLines++
 		}
 	}

--- a/pkg/prompt/prompt.go
+++ b/pkg/prompt/prompt.go
@@ -94,8 +94,8 @@ type Pipe struct {
 
 // Confirm asks for yes or no input
 func (u Pipe) Confirm(message string, defaultValue bool) (bool, error) {
-	fmt.Fprint(u.stdout, message)
+	_, _ = fmt.Fprint(u.stdout, message)
 	var answer string
-	fmt.Scanln(&answer)
+	_, _ = fmt.Scanln(&answer)
 	return utils.StringToBool(answer), nil
 }

--- a/pkg/watch/watcher_darwin.go
+++ b/pkg/watch/watcher_darwin.go
@@ -93,7 +93,7 @@ func (d *fseventNotify) Start() error {
 
 	numberOfWatches.Add(int64(len(d.stream.Paths)))
 
-	d.stream.Start()
+	d.stream.Start() //nolint:errcheck // FIXME(thaJeztah): should this return an error?
 
 	go d.loop()
 


### PR DESCRIPTION
pkg/watch/watcher_darwin.go:96:16: Error return value of `d.stream.Start` is not checked (errcheck)
        d.stream.Start()
                      ^
    pkg/prompt/prompt.go:97:12: Error return value of `fmt.Fprint` is not checked (errcheck)
        fmt.Fprint(u.stdout, message)
                  ^
    pkg/prompt/prompt.go:99:12: Error return value of `fmt.Scanln` is not checked (errcheck)
        fmt.Scanln(&answer)
                  ^
    cmd/formatter/logs.go:118:15: Error return value of `fmt.Fprintf` is not checked (errcheck)
                fmt.Fprintf(w, "%s%s%s\n", p.prefix, timestamp, line)
                           ^
    cmd/formatter/logs.go:120:15: Error return value of `fmt.Fprintf` is not checked (errcheck)
                fmt.Fprintf(w, "%s%s\n", p.prefix, line)
                           ^
    pkg/progress/json.go:67:15: Error return value of `fmt.Fprintln` is not checked (errcheck)
            fmt.Fprintln(p.out, string(marshal))
                        ^
    pkg/progress/json.go:87:15: Error return value of `fmt.Fprintln` is not checked (errcheck)
            fmt.Fprintln(p.out, string(marshal))
                        ^
    pkg/progress/plain.go:47:14: Error return value of `fmt.Fprintln` is not checked (errcheck)
        fmt.Fprintln(p.out, prefix, e.ID, e.Text, e.StatusText)
                    ^
    pkg/progress/tty.go:162:12: Error return value of `fmt.Fprint` is not checked (errcheck)
        fmt.Fprint(w.out, b.Column(0).ANSI)
                  ^
    pkg/progress/tty.go:165:12: Error return value of `fmt.Fprint` is not checked (errcheck)
        fmt.Fprint(w.out, aec.Hide)
                  ^
    pkg/compose/attach.go:53:13: Error return value of `fmt.Fprintf` is not checked (errcheck)
        fmt.Fprintf(s.stdout(), "Attaching to %s\n", strings.Join(names, ", "))
                   ^
    pkg/compose/compose.go:194:6: emptyStringTest: replace `len(dependencies) > 0` with `dependencies != ""` (gocritic)
            if len(dependencies) > 0 {
               ^
    pkg/compose/convergence.go:461:2: builtinShadow: shadowing of predeclared identifier: max (gocritic)
        max := 0
        ^
    pkg/compose/run.go:127:5: emptyStringTest: replace `len(opts.User) > 0` with `opts.User != ""` (gocritic)
        if len(opts.User) > 0 {
           ^
    pkg/compose/run.go:139:5: emptyStringTest: replace `len(opts.WorkingDir) > 0` with `opts.WorkingDir != ""` (gocritic)
        if len(opts.WorkingDir) > 0 {
           ^
    pkg/compose/viz.go:91:8: emptyStringTest: replace `len(portConfig.HostIP) > 0` with `portConfig.HostIP != ""` (gocritic)
                    if len(portConfig.HostIP) > 0 {
                       ^
    cmd/compatibility/convert.go:66:6: emptyStringTest: replace `len(arg) > 0` with `arg != ""` (gocritic)
            if len(arg) > 0 && arg[0] != '-' {
               ^
    pkg/e2e/watch_test.go:208:25: printf: non-constant format string in call to gotest.tools/v3/poll.Continue (govet)
                return poll.Continue(res.Combined())
                                     ^
    pkg/e2e/watch_test.go:290:25: printf: non-constant format string in call to gotest.tools/v3/poll.Continue (govet)
                return poll.Continue(r.Combined())
                                     ^

**What I did**

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
